### PR TITLE
chore: vercel deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "packageManager": "pnpm@8.15.8+sha512.d1a029e1a447ad90bc96cd58b0fad486d2993d531856396f7babf2d83eb1823bb83c5a3d0fc18f675b2d10321d49eb161fece36fe8134aa5823ecd215feed392",
   "scripts": {
     "build": "next build",
+    "build-vercel": "next build && node vercel.mjs",
     "dev": "next dev",
     "lint": "next lint",
     "lint-staged": "lint-staged",
@@ -44,6 +45,7 @@
     "@types/react-dom": "18.2.25",
     "@vercel/git-hooks": "1.0.0",
     "autoprefixer": "10.4.19",
+    "esbuild": "0.21.5",
     "eslint": "9.0.0",
     "eslint-config-next": "14.2.2",
     "lint-staged": "15.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "packageManager": "pnpm@8.15.8+sha512.d1a029e1a447ad90bc96cd58b0fad486d2993d531856396f7babf2d83eb1823bb83c5a3d0fc18f675b2d10321d49eb161fece36fe8134aa5823ecd215feed392",
   "scripts": {
     "build": "next build",
-    "build-vercel": "next build && node vercel.mjs",
     "dev": "next dev",
     "lint": "next lint",
     "lint-staged": "lint-staged",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ devDependencies:
   autoprefixer:
     specifier: 10.4.19
     version: 10.4.19(postcss@8.4.38)
+  esbuild:
+    specifier: 0.21.5
+    version: 0.21.5
   eslint:
     specifier: 9.0.0
     version: 9.0.0
@@ -430,7 +433,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm64@0.21.5:
@@ -439,7 +441,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm@0.21.5:
@@ -448,7 +449,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-x64@0.21.5:
@@ -457,7 +457,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-arm64@0.21.5:
@@ -466,7 +465,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-x64@0.21.5:
@@ -475,7 +473,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-arm64@0.21.5:
@@ -484,7 +481,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-x64@0.21.5:
@@ -493,7 +489,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm64@0.21.5:
@@ -502,7 +497,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm@0.21.5:
@@ -511,7 +505,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ia32@0.21.5:
@@ -520,7 +513,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-loong64@0.21.5:
@@ -529,7 +521,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-mips64el@0.21.5:
@@ -538,7 +529,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ppc64@0.21.5:
@@ -547,7 +537,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-riscv64@0.21.5:
@@ -556,7 +545,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-s390x@0.21.5:
@@ -565,7 +553,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-x64@0.21.5:
@@ -574,7 +561,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/netbsd-x64@0.21.5:
@@ -583,7 +569,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/openbsd-x64@0.21.5:
@@ -592,7 +577,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/sunos-x64@0.21.5:
@@ -601,7 +585,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-arm64@0.21.5:
@@ -610,7 +593,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-ia32@0.21.5:
@@ -619,7 +601,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-x64@0.21.5:
@@ -628,7 +609,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@9.0.0):
@@ -2680,7 +2660,6 @@ packages:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
-    dev: false
 
   /escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
@@ -4698,7 +4677,7 @@ packages:
       neo-async: 2.6.2
       react: 19.0.0-rc-8971381549-20240625
       react-dom: 19.0.0-rc-8971381549-20240625(react@19.0.0-rc-8971381549-20240625)
-      webpack: 5.92.1
+      webpack: 5.92.1(esbuild@0.21.5)
     dev: false
 
   /react@19.0.0-rc-8971381549-20240625:
@@ -5306,7 +5285,7 @@ packages:
       yallist: 4.0.0
     dev: false
 
-  /terser-webpack-plugin@5.3.10(webpack@5.92.1):
+  /terser-webpack-plugin@5.3.10(esbuild@0.21.5)(webpack@5.92.1):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -5323,11 +5302,12 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
+      esbuild: 0.21.5
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.1
-      webpack: 5.92.1
+      webpack: 5.92.1(esbuild@0.21.5)
     dev: false
 
   /terser@5.31.1:
@@ -5722,7 +5702,7 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: false
 
-  /webpack@5.92.1:
+  /webpack@5.92.1(esbuild@0.21.5):
     resolution: {integrity: sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -5753,7 +5733,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.92.1)
+      terser-webpack-plugin: 5.3.10(esbuild@0.21.5)(webpack@5.92.1)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "buildCommand": "pnpm build-vercel"
+  "buildCommand": "pnpm build && node vercel.mjs"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2,
+  "buildCommand": "pnpm build-vercel"
+}

--- a/vercel.mjs
+++ b/vercel.mjs
@@ -1,0 +1,82 @@
+// based on
+// https://github.com/hi-ogawa/vite-plugins/blob/9e2cfc8770344c322f78523237d4b6e9266b9da0/packages/react-server/examples/basic/misc/vercel/build.js#L50-L58
+
+import { cp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import * as esbuild from "esbuild";
+
+const buildDir = join(import.meta.dirname, "dist");
+const outDir = join(import.meta.dirname, ".vercel/output");
+
+const configJson = {
+  version: 3,
+  trailingSlash: false,
+  routes: [
+    {
+      src: "^/assets/(.*)$",
+      headers: {
+        "cache-control": "public, immutable, max-age=31536000",
+      },
+    },
+    {
+      handle: "filesystem",
+    },
+    {
+      src: ".*",
+      dest: "/",
+    },
+  ],
+};
+
+const vcConfigJson = {
+  runtime: "edge",
+  entrypoint: "index.js",
+};
+
+async function main() {
+  // clean
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(outDir, { recursive: true });
+
+  // config
+  await writeFile(
+    join(outDir, "config.json"),
+    JSON.stringify(configJson, null, 2),
+  );
+
+  // static
+  await mkdir(join(outDir, "static"), { recursive: true });
+  await cp(join(buildDir, "client"), join(outDir, "static"), {
+    recursive: true,
+  });
+
+  // function
+  await mkdir(join(outDir, "functions/index.func"), { recursive: true });
+  await writeFile(
+    join(outDir, "functions/index.func/.vc-config.json"),
+    JSON.stringify(vcConfigJson, null, 2),
+  );
+
+  // bundle function
+  const result = await esbuild.build({
+    entryPoints: [join(buildDir, "server/index.js")],
+    outfile: join(outDir, "functions/index.func/index.js"),
+    metafile: true,
+    bundle: true,
+    minify: true,
+    format: "esm",
+    platform: "node",
+    define: {
+      "process.env.NODE_ENV": `"production"`,
+    },
+    logOverride: {
+      "ignored-bare-import": "silent",
+    },
+  });
+  await writeFile(
+    join(outDir, "esbuild-metafile.json"),
+    JSON.stringify(result.metafile),
+  );
+}
+
+main();

--- a/vercel.mjs
+++ b/vercel.mjs
@@ -1,36 +1,46 @@
-// based on
-// https://github.com/hi-ogawa/vite-plugins/blob/9e2cfc8770344c322f78523237d4b6e9266b9da0/packages/react-server/examples/basic/misc/vercel/build.js#L50-L58
+/*
+based on
+https://github.com/hi-ogawa/vite-plugins/blob/9e2cfc8770344c322f78523237d4b6e9266b9da0/packages/react-server/examples/basic/misc/vercel/build.js#L50-L58
 
-import { cp, mkdir, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import * as esbuild from "esbuild";
+// initial setup
+vercel projects add app-router-vite
+vercel link -p app-router-vite
 
-const buildDir = join(import.meta.dirname, "dist");
-const outDir = join(import.meta.dirname, ".vercel/output");
+// deploy
+pnpm build && node vercel.mjs
+vercel deploy --prebuilt --prod
+*/
+
+import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import * as esbuild from 'esbuild';
+
+const buildDir = join(import.meta.dirname, 'dist');
+const outDir = join(import.meta.dirname, '.vercel/output');
 
 const configJson = {
   version: 3,
   trailingSlash: false,
   routes: [
     {
-      src: "^/assets/(.*)$",
+      src: '^/assets/(.*)$',
       headers: {
-        "cache-control": "public, immutable, max-age=31536000",
+        'cache-control': 'public, immutable, max-age=31536000',
       },
     },
     {
-      handle: "filesystem",
+      handle: 'filesystem',
     },
     {
-      src: ".*",
-      dest: "/",
+      src: '.*',
+      dest: '/',
     },
   ],
 };
 
 const vcConfigJson = {
-  runtime: "nodejs20.x",
-  handler: "index.js",
+  runtime: 'nodejs20.x',
+  handler: 'index.mjs',
 };
 
 async function main() {
@@ -40,41 +50,41 @@ async function main() {
 
   // config
   await writeFile(
-    join(outDir, "config.json"),
+    join(outDir, 'config.json'),
     JSON.stringify(configJson, null, 2),
   );
 
   // static
-  await mkdir(join(outDir, "static"), { recursive: true });
-  await cp(join(buildDir, "client"), join(outDir, "static"), {
+  await mkdir(join(outDir, 'static'), { recursive: true });
+  await cp(join(buildDir, 'client'), join(outDir, 'static'), {
     recursive: true,
   });
 
   // function
-  await mkdir(join(outDir, "functions/index.func"), { recursive: true });
+  await mkdir(join(outDir, 'functions/index.func'), { recursive: true });
   await writeFile(
-    join(outDir, "functions/index.func/.vc-config.json"),
+    join(outDir, 'functions/index.func/.vc-config.json'),
     JSON.stringify(vcConfigJson, null, 2),
   );
 
   // bundle function
   const result = await esbuild.build({
-    entryPoints: [join(buildDir, "server/index.js")],
-    outfile: join(outDir, "functions/index.func/index.js"),
+    entryPoints: [join(buildDir, 'server/index.js')],
+    outfile: join(outDir, 'functions/index.func/index.mjs'),
     metafile: true,
     bundle: true,
     minify: true,
-    format: "esm",
-    platform: "node",
+    format: 'esm',
+    platform: 'node',
     define: {
-      "process.env.NODE_ENV": `"production"`,
+      'process.env.NODE_ENV': `"production"`,
     },
     logOverride: {
-      "ignored-bare-import": "silent",
+      'ignored-bare-import': 'silent',
     },
   });
   await writeFile(
-    join(outDir, "esbuild-metafile.json"),
+    join(outDir, 'esbuild-metafile.json'),
     JSON.stringify(result.metafile),
   );
 }

--- a/vercel.mjs
+++ b/vercel.mjs
@@ -29,8 +29,8 @@ const configJson = {
 };
 
 const vcConfigJson = {
-  runtime: "edge",
-  entrypoint: "index.js",
+  runtime: "nodejs20.x",
+  handler: "index.js",
 };
 
 async function main() {


### PR DESCRIPTION
We could probably have this build script provided from `react-server-next` cli directly. Also, we use node adapter (same as dev), but we could try edge adapter as well.

Actually, I was thinking to have a dedicated package to collect build scripts, so we could make that and add it as an dependency of `react-server-next`.