### PR TITLE
chore: vercel one-click deploy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+ "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2,
+  "framework": null
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
- "$schema": "https://openapi.vercel.sh/vercel.json",
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "framework": null
 }


### PR DESCRIPTION
Well, it looks like vercel understandably mis-detects framework as Next.js, so we might need to force `framework: null`.

```
Warning: Could not identify Next.js version, ensure it is defined as a project dependency.
Error: No Next.js version could be detected in your project. Make sure `"next"` is installed in "dependencies" or "devDependencies"
```

Not being able to do zero-config is unfortunate, but this should work now.

[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fhi-ogawa%2Fnext-app-router-playground%2Ftree%2Fchore-one-click-vercel)