### PR TITLE
chore: tweak external to improve startup

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -6,6 +6,25 @@ export default defineConfig((env) => ({
     next({
       // ssg is opt-in for now
       prerender: (_, presets) => presets.generateStaticParams(),
+      plugins: [
+        {
+          name: 'config',
+          apply: 'serve',
+          config() {
+            return {
+              ssr: {
+                optimizeDeps: {
+                  include: [
+                    '@heroicons/react/24/outline',
+                    '@heroicons/react/24/solid',
+                  ],
+                },
+                external: ['date-fns', 'dinero.js'],
+              },
+            };
+          },
+        },
+      ],
     }),
   ],
   ssr: {


### PR DESCRIPTION
When running `DEBUG=vite:transform pnpm dev`, I noticed the excessive amount of transforms and it looks like externalizing some of it would help startup. Still react related deps cannot be externalized, so they needs to be in `optimizeDeps` explicitly.


```
# before
  VITE v5.3.1  ready in 229 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
  --> GET /
  <-- GET / 200 1.2s

# after
  --> GET /
  <-- GET / 200 959ms
```

It also interesting to compare for raw flight request http://localhost:5173/__f.data since this doesn't involve css crawling.
