### PR TITLE
fix: workaround styled-components broken import

### DIFF
--- a/app/styling/styled-components/page.tsx
+++ b/app/styling/styled-components/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-// https://github.com/styled-components/styled-components/issues/4268
-// https://github.com/styled-components/styled-components/issues/4275
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 const Container = styled.div`
   display: grid;

--- a/app/styling/styled-components/page.tsx
+++ b/app/styling/styled-components/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import styled from 'styled-components';
+// https://github.com/styled-components/styled-components/issues/4268
+// https://github.com/styled-components/styled-components/issues/4275
+import { styled } from 'styled-components';
 
 const Container = styled.div`
   display: grid;

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -3,4 +3,9 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [next()],
+  ssr: {
+    // https://github.com/styled-components/styled-components/issues/4268
+    // https://github.com/styled-components/styled-components/issues/4275
+    noExternal: ["styled-components"]
+  }
 });


### PR DESCRIPTION
`useServerInsertedHTML` from https://github.com/hi-ogawa/vite-plugins/pull/536 seems fine, but I remembered `styled-components` exports are broken in esm, so this needs to be inline for ssr.