### PR TITLE
chore: test rolldown-vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "styled-jsx": "5.1.6",
     "use-count-up": "3.0.1",
     "vercel": "34.0.0",
-    "vite": "^6"
+    "vite": "https://pkg.pr.new/rolldown/vite@7e5a8b6"
   },
   "devDependencies": {
     "@tailwindcss/forms": "0.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 2.1.3(react@19.0.0)
   '@hiogawa/react-server':
     specifier: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server@e154a87
-    version: '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server@e154a87(react-dom@19.0.0)(react-server-dom-webpack@19.0.0)(react@19.0.0)(vite@6.0.11)'
+    version: '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server@e154a87(react-dom@19.0.0)(react-server-dom-webpack@19.0.0)(react@19.0.0)(vite@6.1.0)'
   clsx:
     specifier: 2.1.1
     version: 2.1.1
@@ -25,7 +25,7 @@ dependencies:
     version: 3.0.0-canary.1
   next:
     specifier: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server-next@e154a87
-    version: '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server-next@e154a87(@hiogawa/react-server@0.4.1)(react-dom@19.0.0)(react@19.0.0)(typescript@5.4.5)(vite@6.0.11)'
+    version: '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server-next@e154a87(@hiogawa/react-server@0.4.1)(react-dom@19.0.0)(react@19.0.0)(typescript@5.4.5)(vite@6.1.0)'
   react:
     specifier: ^19
     version: 19.0.0
@@ -34,7 +34,7 @@ dependencies:
     version: 19.0.0(react@19.0.0)
   react-server-dom-webpack:
     specifier: ^19
-    version: 19.0.0(react-dom@19.0.0)(react@19.0.0)(webpack@5.92.1)
+    version: 19.0.0(react-dom@19.0.0)(react@19.0.0)(webpack@5.98.0)
   server-only:
     specifier: 0.0.1
     version: 0.0.1
@@ -51,8 +51,8 @@ dependencies:
     specifier: 34.0.0
     version: 34.0.0
   vite:
-    specifier: ^6
-    version: 6.0.11(@types/node@20.12.7)
+    specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+    version: '@pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.12.7)(typescript@5.4.5)'
 
 devDependencies:
   '@tailwindcss/forms':
@@ -69,10 +69,10 @@ devDependencies:
     version: 20.12.7
   '@types/react':
     specifier: ^19
-    version: 19.0.1
+    version: 19.0.10
   '@types/react-dom':
     specifier: ^19
-    version: 19.0.1
+    version: 19.0.4(@types/react@19.0.10)
   '@vercel/git-hooks':
     specifier: 1.0.0
     version: 1.0.0
@@ -172,6 +172,31 @@ packages:
     dependencies:
       '@edge-runtime/primitives': 4.1.0
     dev: false
+
+  /@emnapi/core@1.3.1:
+    resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
+    requiresBuild: true
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.1
+      tslib: 2.5.0
+    dev: false
+    optional: true
+
+  /@emnapi/runtime@1.3.1:
+    resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.5.0
+    dev: false
+    optional: true
+
+  /@emnapi/wasi-threads@1.0.1:
+    resolution: {integrity: sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.5.0
+    dev: false
+    optional: true
 
   /@emotion/is-prop-valid@1.2.1:
     resolution: {integrity: sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==}
@@ -555,6 +580,16 @@ packages:
       - supports-color
     dev: false
 
+  /@napi-rs/wasm-runtime@0.2.6:
+    resolution: {integrity: sha512-z8YVS3XszxFTO73iwvFDNpQIzdMmSDTP/mB3E/ucR37V3Sx57hSExcXyMoNwaucWxnsWf4xfbZv0iZ30jr0M4Q==}
+    requiresBuild: true
+    dependencies:
+      '@emnapi/core': 1.3.1
+      '@emnapi/runtime': 1.3.1
+      '@tybys/wasm-util': 0.9.0
+    dev: false
+    optional: true
+
   /@next/eslint-plugin-next@14.2.2:
     resolution: {integrity: sha512-q+Ec2648JtBpKiu/FSJm8HAsFXlNvioHeBCbTP12T1SGcHYwhqHULSfQgFkPgHDu3kzNp2Kem4J54bK4rPQ5SQ==}
     dependencies:
@@ -579,6 +614,15 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
+  /@oxc-project/runtime@0.51.0:
+    resolution: {integrity: sha512-s/G0/yOpmcD9QY8O1wc4G7nb7BRV9m206PvfM/t3oPu6z+2vyZlfB2kTA9P6vMXO2fzquDMw3G22kCXx4qzfUQ==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@oxc-project/types@0.51.0:
+    resolution: {integrity: sha512-rDHFQBU2lS0Fh1t1rgvSWK21OfgkzjIWqj+FKKRJueecgvdZ6hO+qqstwBy2v9lFhg2DPuaDdLyCXZNGwsKjMw==}
+    dev: false
+
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -591,6 +635,104 @@ packages:
     engines: {node: '>= 10'}
     dev: false
 
+  /@rolldown/binding-darwin-arm64@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-89SghJmrU7zH3dt7J1Vgd2x49T6KIsEvI4mmcfb0VG7L1sR392za4q+doQsNJifVC+onUBx40jnwYHMEdberXg==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rolldown/binding-darwin-x64@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-7SUzG5q3fu6Sh2Jausn/zJCCU/aygE5YAIBg/tT0ojpfDezrlVrsm0gKf0OfE2c1GeC3wNpZcNDmnZo3wKdK+g==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rolldown/binding-freebsd-x64@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-WjqVaI3L7GjebX7L1YnvqqshgFPh9bThlJjpm20LmQl8nrcukZh5iw0js0aE+a8FZOltOR6GVN1knBYF9YJpmw==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-BpUmsD+gmI3t1fs9ofn4hgE5ukaxrmauViBOFpHCdOQZkK2d+jPOQCRSphK+GFxY3rsLzfBkWY4AXOuW+YZLKg==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rolldown/binding-linux-arm64-gnu@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-3dW77dszpSvB54qcbHGztkUF5OoYwP21Q5W955HdybMDoM6V6nDfW+Nyp2d1zQmyXxaAzMDSwTP3PfgZqAqWLw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rolldown/binding-linux-arm64-musl@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-xNHLIfoDvMb5CwEtVy/TmDtfhTR4yS3LBNQkLww7AH09NrLT2PEV23THICNJh03UxgANLkWhkJgRlIeBkOKjIw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rolldown/binding-linux-x64-gnu@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-lUy5d6wC1/QiiNHI/Au+hqTWe2ZDMtaT6yOWz91JGnskFN35tc/QRuz5ptCFjJFMHFz82T8NGUidERXI1+dl+g==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rolldown/binding-linux-x64-musl@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-B7Qb8BnJJkDRJ6hfA8u30K9BGGxQFzz6aVhfpQXhIoLN5VErJh/LLpiJJgYuJzbngqKtGUbu54XJ0vokNzji/g==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rolldown/binding-wasm32-wasi@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-tn9fu3l4aKktb964gOd1FPd34/UpEImyU3sfl6zIQXkAcksHw6YNcD/aPdINFNbLUToYdg5E2NLHnGYjvLnpRw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [wasm32]
+    requiresBuild: true
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.6
+    dev: false
+    optional: true
+
+  /@rolldown/binding-win32-arm64-msvc@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-Z+c0RACfOJWm32BClafn2QKJg1i4+H+bDvaEUWS44GuY6Pri6QWlwrPe9PR9gz/7+L75XKe2nBTAq4FKrtaD9w==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rolldown/binding-win32-ia32-msvc@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-NqfFVOPIxvbX8eZwm4je3cZhwQpC7V9Vo/SCSuZgYVEeHXlsazbLbwF27Kkv16wIHsijRViEO/uEhW8yPRUcnw==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rolldown/binding-win32-x64-msvc@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-G8Dkwmtq+K5hZsDZQds7fPfbbmhHJO7V3hcMJIP+mubEJ5280J2BPv35QVRsA/xVLEEbrmutXajbho9xx+/IlQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@rollup/pluginutils@4.2.1:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
     engines: {node: '>= 8.0.0'}
@@ -598,158 +740,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
     dev: false
-
-  /@rollup/rollup-android-arm-eabi@4.31.0:
-    resolution: {integrity: sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA==}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-android-arm64@4.31.0:
-    resolution: {integrity: sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g==}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-darwin-arm64@4.31.0:
-    resolution: {integrity: sha512-WHIZfXgVBX30SWuTMhlHPXTyN20AXrLH4TEeH/D0Bolvx9PjgZnn4H677PlSGvU6MKNsjCQJYczkpvBbrBnG6g==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-darwin-x64@4.31.0:
-    resolution: {integrity: sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-freebsd-arm64@4.31.0:
-    resolution: {integrity: sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew==}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-freebsd-x64@4.31.0:
-    resolution: {integrity: sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA==}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-arm-gnueabihf@4.31.0:
-    resolution: {integrity: sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-arm-musleabihf@4.31.0:
-    resolution: {integrity: sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-arm64-gnu@4.31.0:
-    resolution: {integrity: sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-arm64-musl@4.31.0:
-    resolution: {integrity: sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-loongarch64-gnu@4.31.0:
-    resolution: {integrity: sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-powerpc64le-gnu@4.31.0:
-    resolution: {integrity: sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-riscv64-gnu@4.31.0:
-    resolution: {integrity: sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-s390x-gnu@4.31.0:
-    resolution: {integrity: sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-x64-gnu@4.31.0:
-    resolution: {integrity: sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-x64-musl@4.31.0:
-    resolution: {integrity: sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-win32-arm64-msvc@4.31.0:
-    resolution: {integrity: sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-win32-ia32-msvc@4.31.0:
-    resolution: {integrity: sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-win32-x64-msvc@4.31.0:
-    resolution: {integrity: sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@rushstack/eslint-patch@1.10.2:
     resolution: {integrity: sha512-hw437iINopmQuxWPSUEvqE56NCPsiU8N4AYtfHmJFckclktzK9YQJieD3XkDCDH4OjL+C7zgPUh73R/nrcHrqw==}
@@ -768,8 +758,8 @@ packages:
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
     dev: false
 
-  /@swc/core-darwin-arm64@1.10.9:
-    resolution: {integrity: sha512-XTHLtijFervv2B+i1ngM993umhSj9K1IeMomvU/Db84Asjur2XmD4KXt9QPnGDRFgv2kLSjZ+DDL25Qk0f4r+w==}
+  /@swc/core-darwin-arm64@1.10.18:
+    resolution: {integrity: sha512-FdGqzAIKVQJu8ROlnHElP59XAUsUzCFSNsou+tY/9ba+lhu8R9v0OI5wXiPErrKGZpQFMmx/BPqqhx3X4SuGNg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -777,8 +767,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-darwin-x64@1.10.9:
-    resolution: {integrity: sha512-bi3el9/FV/la8HIsolSjeDar+tM7m9AmSF1w7X6ZByW2qgc4Z1tmq0A4M4H9aH3TfHesZbfq8hgaNtc2/VtzzQ==}
+  /@swc/core-darwin-x64@1.10.18:
+    resolution: {integrity: sha512-RZ73gZRituL/ZVLgrW6BYnQ5g8tuStG4cLUiPGJsUZpUm0ullSH6lHFvZTCBNFTfpQChG6eEhi2IdG6DwFp1lw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -786,8 +776,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm-gnueabihf@1.10.9:
-    resolution: {integrity: sha512-xsLHV02S+RTDuI+UJBkA2muNk/s0ETRpoc1K/gNt0i8BqTurPYkrvGDDALN9+leiUPydHvZi9P1qdExbgUJnXw==}
+  /@swc/core-linux-arm-gnueabihf@1.10.18:
+    resolution: {integrity: sha512-8iJqI3EkxJuuq21UHoen1VS+QlS23RvynRuk95K+Q2HBjygetztCGGEc+Xelx9a0uPkDaaAtFvds4JMDqb9SAA==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -795,8 +785,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm64-gnu@1.10.9:
-    resolution: {integrity: sha512-41hJgPoGhIa12U6Tud+yLF/m64YA3mGut3TmBEkj2R7rdJdE0mljdtR0tf4J2RoQaWZPPi0DBSqGdROiAEx9dg==}
+  /@swc/core-linux-arm64-gnu@1.10.18:
+    resolution: {integrity: sha512-8f1kSktWzMB6PG+r8lOlCfXz5E8Qhsmfwonn77T/OfjvGwQaWrcoASh2cdjpk3dydbf8jsKGPQE1lSc7GyjXRQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -804,8 +794,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm64-musl@1.10.9:
-    resolution: {integrity: sha512-DUMRhl49b9r7bLg9oNzCdW4lLcDJKrRBn87Iq5APPvixsm1auGnsVQycGkQcDDKvVllxIFSbmCYzjagx3l8Hnw==}
+  /@swc/core-linux-arm64-musl@1.10.18:
+    resolution: {integrity: sha512-4rv+E4VLdgQw6zjbTAauCAEExxChvxMpBUMCiZweTNPKbJJ2dY6BX2WGJ1ea8+RcgqR/Xysj3AFbOz1LBz6dGA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -813,8 +803,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-x64-gnu@1.10.9:
-    resolution: {integrity: sha512-xW0y88vQvmzYo3Gn7yFnY03TfHMwuca4aFH3ZmhwDNOYHmTOi6fmhAkg/13F/NrwjMYO+GnF5uJTjdjb3B6tdQ==}
+  /@swc/core-linux-x64-gnu@1.10.18:
+    resolution: {integrity: sha512-vTNmyRBVP+sZca+vtwygYPGTNudTU6Gl6XhaZZ7cEUTBr8xvSTgEmYXoK/2uzyXpaTUI4Bmtp1x81cGN0mMoLQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -822,8 +812,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-x64-musl@1.10.9:
-    resolution: {integrity: sha512-jYs32BEx+CPVuxN6NdsWEpdehjnmAag25jyJzwjQx+NCGYwHEV3bT5y8TX4eFhaVB1rafmqJOlYQPs4+MSyGCg==}
+  /@swc/core-linux-x64-musl@1.10.18:
+    resolution: {integrity: sha512-1TZPReKhFCeX776XaT6wegknfg+g3zODve+r4oslFHI+g7cInfWlxoGNDS3niPKyuafgCdOjme2g3OF+zzxfsQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -831,8 +821,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-arm64-msvc@1.10.9:
-    resolution: {integrity: sha512-Uhh5T3Fq3Nyom96Bm3ACBNASH3iqNc76in7ewZz8PooUqeTIO8aZpsghnncjctRNE9T819/8btpiFIhHo3sKtg==}
+  /@swc/core-win32-arm64-msvc@1.10.18:
+    resolution: {integrity: sha512-o/2CsaWSN3bkzVQ6DA+BiFKSVEYvhWGA1h+wnL2zWmIDs2Knag54sOEXZkCaf8YQyZesGeXJtPEy9hh/vjJgkA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -840,8 +830,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-ia32-msvc@1.10.9:
-    resolution: {integrity: sha512-bD5BpbojEsDfrAvT+1qjQPf5RCKLg4UL+3Uwm019+ZR02hd8qO538BlOnQdOqRqccu+75DF6aRglQ7AJ24Cs0Q==}
+  /@swc/core-win32-ia32-msvc@1.10.18:
+    resolution: {integrity: sha512-eTPASeJtk4mJDfWiYEiOC6OYUi/N7meHbNHcU8e+aKABonhXrIo/FmnTE8vsUtC6+jakT1TQBdiQ8fzJ1kJVwA==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -849,8 +839,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-x64-msvc@1.10.9:
-    resolution: {integrity: sha512-NwkuUNeBBQnAaXVvcGw8Zr6RR8kylyjFUnlYZZ3G0QkQZ4rYLXYTafAmiRjrfzgVb0LcMF/sBzJvGOk7SwtIDg==}
+  /@swc/core-win32-x64-msvc@1.10.18:
+    resolution: {integrity: sha512-1Dud8CDBnc34wkBOboFBQud9YlV1bcIQtKSg7zC8LtwR3h+XAaCayZPkpGmmAlCv1DLQPvkF+s0JcaVC9mfffQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -858,8 +848,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core@1.10.9:
-    resolution: {integrity: sha512-MQ97YSXu2oibzm7wi4GNa7hhndjLuVt/lmO2sq53+P37oZmyg/JQ/IYYtSiC6UGK3+cHoiVAykrK+glxLjJbag==}
+  /@swc/core@1.10.18:
+    resolution: {integrity: sha512-IUWKD6uQYGRy8w2X9EZrtYg1O3SCijlHbCXzMaHQYc1X7yjijQh4H3IVL9ssZZyVp2ZDfQZu4bD5DWxxvpyjvg==}
     engines: {node: '>=10'}
     requiresBuild: true
     peerDependencies:
@@ -871,16 +861,16 @@ packages:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.17
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.10.9
-      '@swc/core-darwin-x64': 1.10.9
-      '@swc/core-linux-arm-gnueabihf': 1.10.9
-      '@swc/core-linux-arm64-gnu': 1.10.9
-      '@swc/core-linux-arm64-musl': 1.10.9
-      '@swc/core-linux-x64-gnu': 1.10.9
-      '@swc/core-linux-x64-musl': 1.10.9
-      '@swc/core-win32-arm64-msvc': 1.10.9
-      '@swc/core-win32-ia32-msvc': 1.10.9
-      '@swc/core-win32-x64-msvc': 1.10.9
+      '@swc/core-darwin-arm64': 1.10.18
+      '@swc/core-darwin-x64': 1.10.18
+      '@swc/core-linux-arm-gnueabihf': 1.10.18
+      '@swc/core-linux-arm64-gnu': 1.10.18
+      '@swc/core-linux-arm64-musl': 1.10.18
+      '@swc/core-linux-x64-gnu': 1.10.18
+      '@swc/core-linux-x64-musl': 1.10.18
+      '@swc/core-win32-arm64-msvc': 1.10.18
+      '@swc/core-win32-ia32-msvc': 1.10.18
+      '@swc/core-win32-x64-msvc': 1.10.18
     dev: false
 
   /@swc/counter@0.1.3:
@@ -944,15 +934,23 @@ packages:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: false
 
+  /@tybys/wasm-util@0.9.0:
+    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.5.0
+    dev: false
+    optional: true
+
   /@types/eslint-scope@3.7.7:
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
     dependencies:
-      '@types/eslint': 8.56.10
+      '@types/eslint': 9.6.1
       '@types/estree': 1.0.6
     dev: false
 
-  /@types/eslint@8.56.10:
-    resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
+  /@types/eslint@9.6.1:
+    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
     dependencies:
       '@types/estree': 1.0.6
       '@types/json-schema': 7.0.15
@@ -983,14 +981,16 @@ packages:
     dependencies:
       undici-types: 5.26.5
 
-  /@types/react-dom@19.0.1:
-    resolution: {integrity: sha512-hljHij7MpWPKF6u5vojuyfV0YA4YURsQG7KT6SzV0Zs2BXAtgdTxG6A229Ub/xiWV4w/7JL8fi6aAyjshH4meA==}
+  /@types/react-dom@19.0.4(@types/react@19.0.10):
+    resolution: {integrity: sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==}
+    peerDependencies:
+      '@types/react': ^19.0.0
     dependencies:
-      '@types/react': 19.0.1
+      '@types/react': 19.0.10
     dev: true
 
-  /@types/react@19.0.1:
-    resolution: {integrity: sha512-YW6614BDhqbpR5KtUYzTA+zlA7nayzJRA9ljz9CQoxthR0sDisYZLuvSMsil36t4EH/uAt8T52Xb4sVw17G+SQ==}
+  /@types/react@19.0.10:
+    resolution: {integrity: sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==}
     dependencies:
       csstype: 3.1.2
     dev: true
@@ -1062,6 +1062,14 @@ packages:
       '@typescript-eslint/types': 7.2.0
       eslint-visitor-keys: 3.4.3
     dev: true
+
+  /@valibot/to-json-schema@1.0.0-beta.5(valibot@1.0.0-beta.14):
+    resolution: {integrity: sha512-8aI2sG98gWS+6YuIL3OMkg60sImhICPdZIFCV1XDyX8k6UOCX+MgXaeR3f2fDShuNXYHV46vcjWRpov8ojzDNw==}
+    peerDependencies:
+      valibot: ^1.0.0 || ^1.0.0-beta.5 || ^1.0.0-rc
+    dependencies:
+      valibot: 1.0.0-beta.14(typescript@5.4.5)
+    dev: false
 
   /@vercel/build-utils@7.11.0:
     resolution: {integrity: sha512-UFrx1hNIjNJJkd0NZrYfaOrmcWhQmrVsbKe9o3L9jX9J1iufG685wIZ9tFCKKC0Fa2HWbNDNzNxrE5SCAS2lyA==}
@@ -1259,120 +1267,120 @@ packages:
       ts-morph: 12.0.0
     dev: false
 
-  /@vitejs/plugin-react-swc@3.7.2(vite@6.0.11):
-    resolution: {integrity: sha512-y0byko2b2tSVVf5Gpng1eEhX1OvPC7x8yns1Fx8jDzlJp4LS6CMkCPfLw47cjyoMrshQDoQw4qcgjsU9VvlCew==}
+  /@vitejs/plugin-react-swc@3.8.0(vite@6.1.0):
+    resolution: {integrity: sha512-T4sHPvS+DIqDP51ifPqa9XIRAz/kIvIi8oXcnOZZgHmMotgmmdxe/DD5tMFlt5nuIRzT0/QuiwmKlH0503Aapw==}
     peerDependencies:
       vite: ^4 || ^5 || ^6
     dependencies:
-      '@swc/core': 1.10.9
-      vite: 6.0.11(@types/node@20.12.7)
+      '@swc/core': 1.10.18
+      vite: '@pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.12.7)(typescript@5.4.5)'
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: false
 
-  /@webassemblyjs/ast@1.12.1:
-    resolution: {integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==}
+  /@webassemblyjs/ast@1.14.1:
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
     dependencies:
-      '@webassemblyjs/helper-numbers': 1.11.6
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
     dev: false
 
-  /@webassemblyjs/floating-point-hex-parser@1.11.6:
-    resolution: {integrity: sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==}
+  /@webassemblyjs/floating-point-hex-parser@1.13.2:
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
     dev: false
 
-  /@webassemblyjs/helper-api-error@1.11.6:
-    resolution: {integrity: sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==}
+  /@webassemblyjs/helper-api-error@1.13.2:
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
     dev: false
 
-  /@webassemblyjs/helper-buffer@1.12.1:
-    resolution: {integrity: sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==}
+  /@webassemblyjs/helper-buffer@1.14.1:
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
     dev: false
 
-  /@webassemblyjs/helper-numbers@1.11.6:
-    resolution: {integrity: sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==}
+  /@webassemblyjs/helper-numbers@1.13.2:
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
     dependencies:
-      '@webassemblyjs/floating-point-hex-parser': 1.11.6
-      '@webassemblyjs/helper-api-error': 1.11.6
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
       '@xtuc/long': 4.2.2
     dev: false
 
-  /@webassemblyjs/helper-wasm-bytecode@1.11.6:
-    resolution: {integrity: sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==}
+  /@webassemblyjs/helper-wasm-bytecode@1.13.2:
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
     dev: false
 
-  /@webassemblyjs/helper-wasm-section@1.12.1:
-    resolution: {integrity: sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==}
+  /@webassemblyjs/helper-wasm-section@1.14.1:
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
     dependencies:
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/helper-buffer': 1.12.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
-      '@webassemblyjs/wasm-gen': 1.12.1
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
     dev: false
 
-  /@webassemblyjs/ieee754@1.11.6:
-    resolution: {integrity: sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==}
+  /@webassemblyjs/ieee754@1.13.2:
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
     dev: false
 
-  /@webassemblyjs/leb128@1.11.6:
-    resolution: {integrity: sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==}
+  /@webassemblyjs/leb128@1.13.2:
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
     dependencies:
       '@xtuc/long': 4.2.2
     dev: false
 
-  /@webassemblyjs/utf8@1.11.6:
-    resolution: {integrity: sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==}
+  /@webassemblyjs/utf8@1.13.2:
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
     dev: false
 
-  /@webassemblyjs/wasm-edit@1.12.1:
-    resolution: {integrity: sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==}
+  /@webassemblyjs/wasm-edit@1.14.1:
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
     dependencies:
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/helper-buffer': 1.12.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
-      '@webassemblyjs/helper-wasm-section': 1.12.1
-      '@webassemblyjs/wasm-gen': 1.12.1
-      '@webassemblyjs/wasm-opt': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      '@webassemblyjs/wast-printer': 1.12.1
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
     dev: false
 
-  /@webassemblyjs/wasm-gen@1.12.1:
-    resolution: {integrity: sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==}
+  /@webassemblyjs/wasm-gen@1.14.1:
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
     dependencies:
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
-      '@webassemblyjs/ieee754': 1.11.6
-      '@webassemblyjs/leb128': 1.11.6
-      '@webassemblyjs/utf8': 1.11.6
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
     dev: false
 
-  /@webassemblyjs/wasm-opt@1.12.1:
-    resolution: {integrity: sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==}
+  /@webassemblyjs/wasm-opt@1.14.1:
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
     dependencies:
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/helper-buffer': 1.12.1
-      '@webassemblyjs/wasm-gen': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
     dev: false
 
-  /@webassemblyjs/wasm-parser@1.12.1:
-    resolution: {integrity: sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==}
+  /@webassemblyjs/wasm-parser@1.14.1:
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
     dependencies:
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/helper-api-error': 1.11.6
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
-      '@webassemblyjs/ieee754': 1.11.6
-      '@webassemblyjs/leb128': 1.11.6
-      '@webassemblyjs/utf8': 1.11.6
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
     dev: false
 
-  /@webassemblyjs/wast-printer@1.12.1:
-    resolution: {integrity: sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==}
+  /@webassemblyjs/wast-printer@1.14.1:
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
     dependencies:
-      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
     dev: false
 
@@ -1421,6 +1429,12 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  /acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: false
+
   /agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -1430,12 +1444,24 @@ packages:
       - supports-color
     dev: false
 
-  /ajv-keywords@3.5.2(ajv@6.12.6):
-    resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
+  /ajv-formats@2.1.1(ajv@8.17.1):
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
-      ajv: ^6.9.1
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
-      ajv: 6.12.6
+      ajv: 8.17.1
+    dev: false
+
+  /ajv-keywords@5.1.0(ajv@8.17.1):
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
+    dependencies:
+      ajv: 8.17.1
+      fast-deep-equal: 3.1.3
     dev: false
 
   /ajv@6.12.6:
@@ -1445,6 +1471,15 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  /ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+    dev: false
 
   /ajv@8.6.3:
     resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
@@ -1737,15 +1772,15 @@ packages:
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
     dev: true
 
-  /browserslist@4.23.2:
-    resolution: {integrity: sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==}
+  /browserslist@4.24.4:
+    resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001642
-      electron-to-chromium: 1.4.827
-      node-releases: 2.0.14
-      update-browserslist-db: 1.1.0(browserslist@4.23.2)
+      caniuse-lite: 1.0.30001700
+      electron-to-chromium: 1.5.102
+      node-releases: 2.0.19
+      update-browserslist-db: 1.1.2(browserslist@4.24.4)
     dev: false
 
   /buffer-crc32@0.2.13:
@@ -1790,8 +1825,8 @@ packages:
     resolution: {integrity: sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==}
     dev: true
 
-  /caniuse-lite@1.0.30001642:
-    resolution: {integrity: sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==}
+  /caniuse-lite@1.0.30001700:
+    resolution: {integrity: sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==}
     dev: false
 
   /chalk@4.1.2:
@@ -2085,6 +2120,12 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+    dev: false
+
   /detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
     engines: {node: '>=8'}
@@ -2149,8 +2190,8 @@ packages:
     resolution: {integrity: sha512-Yvg5i+iyv7Xm18BRdVPVm8lc7kgxM3r6iwqCH2zB7QZy1kZRNmd0Zqm0zcD9XoFREE5/5rwIuIAOT+/mzGcnZg==}
     dev: true
 
-  /electron-to-chromium@1.4.827:
-    resolution: {integrity: sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==}
+  /electron-to-chromium@1.5.102:
+    resolution: {integrity: sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==}
     dev: false
 
   /emoji-regex@10.3.0:
@@ -2183,8 +2224,8 @@ packages:
       tapable: 2.2.1
     dev: true
 
-  /enhanced-resolve@5.17.0:
-    resolution: {integrity: sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==}
+  /enhanced-resolve@5.18.1:
+    resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.11
@@ -2558,6 +2599,12 @@ packages:
   /escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
+    dev: true
+
+  /escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+    dev: false
 
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -2946,6 +2993,10 @@ packages:
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
+
+  /fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+    dev: false
 
   /fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -3509,8 +3560,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /is-reference@3.0.2:
-    resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
+  /is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
     dependencies:
       '@types/estree': 1.0.6
     dev: false
@@ -3721,6 +3772,114 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
     dev: true
+
+  /lightningcss-darwin-arm64@1.29.1:
+    resolution: {integrity: sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-darwin-x64@1.29.1:
+    resolution: {integrity: sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-freebsd-x64@1.29.1:
+    resolution: {integrity: sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-linux-arm-gnueabihf@1.29.1:
+    resolution: {integrity: sha512-sD32pFvlR0kDlqsOZmYqH/68SqUMPNj+0pucGxToXZi4XZgZmqeX/NkxNKCPsswAXU3UeYgDSpGhu05eAufjDg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-linux-arm64-gnu@1.29.1:
+    resolution: {integrity: sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-linux-arm64-musl@1.29.1:
+    resolution: {integrity: sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-linux-x64-gnu@1.29.1:
+    resolution: {integrity: sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-linux-x64-musl@1.29.1:
+    resolution: {integrity: sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-win32-arm64-msvc@1.29.1:
+    resolution: {integrity: sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-win32-x64-msvc@1.29.1:
+    resolution: {integrity: sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss@1.29.1:
+    resolution: {integrity: sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      detect-libc: 1.0.3
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.29.1
+      lightningcss-darwin-x64: 1.29.1
+      lightningcss-freebsd-x64: 1.29.1
+      lightningcss-linux-arm-gnueabihf: 1.29.1
+      lightningcss-linux-arm64-gnu: 1.29.1
+      lightningcss-linux-arm64-musl: 1.29.1
+      lightningcss-linux-x64-gnu: 1.29.1
+      lightningcss-linux-x64-musl: 1.29.1
+      lightningcss-win32-arm64-msvc: 1.29.1
+      lightningcss-win32-x64-msvc: 1.29.1
+    dev: false
 
   /lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -4067,6 +4226,11 @@ packages:
 
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+    dev: true
+
+  /node-releases@2.0.19:
+    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+    dev: false
 
   /nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
@@ -4335,7 +4499,7 @@ packages:
     resolution: {integrity: sha512-sqpQDUy8vgB7ycLkendSKS6HnVz1Rneoc3Rc+ZBUCe2pbqlVuCC5vF52l0NJ1aiMg/r1qfYF9/myz8CZeI2rjA==}
     dependencies:
       '@types/estree': 1.0.6
-      is-reference: 3.0.2
+      is-reference: 3.0.3
       zimmerframe: 1.1.2
     dev: false
 
@@ -4457,8 +4621,8 @@ packages:
       source-map-js: 1.2.0
     dev: true
 
-  /postcss@8.5.1:
-    resolution: {integrity: sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==}
+  /postcss@8.5.3:
+    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.8
@@ -4594,7 +4758,7 @@ packages:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: true
 
-  /react-server-dom-webpack@19.0.0(react-dom@19.0.0)(react@19.0.0)(webpack@5.92.1):
+  /react-server-dom-webpack@19.0.0(react-dom@19.0.0)(react@19.0.0)(webpack@5.98.0):
     resolution: {integrity: sha512-hLug9KEXLc8vnU9lDNe2b2rKKDaqrp5gNiES4uyu2Up3FZfZJZmdwLFXlWzdA9gTB/6/cWduSB2K1Lfag2pSvw==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
@@ -4606,7 +4770,7 @@ packages:
       neo-async: 2.6.2
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      webpack: 5.92.1
+      webpack: 5.98.0
       webpack-sources: 3.2.3
     dev: false
 
@@ -4731,33 +4895,34 @@ packages:
       glob: 7.2.3
     dev: false
 
-  /rollup@4.31.0:
-    resolution: {integrity: sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+  /rolldown@1.0.0-beta.3-commit.b546e53(@oxc-project/runtime@0.51.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-boMVf8ecS38Kczjb+8LDnfOSXy9ldpsv4sfrPsPJYBsc0Wo/cam+IrOotCWPvGXQeIyxuh3PaWMfLbVZW+hTwg==}
     hasBin: true
+    peerDependencies:
+      '@oxc-project/runtime': 0.51.0
+    peerDependenciesMeta:
+      '@oxc-project/runtime':
+        optional: true
     dependencies:
-      '@types/estree': 1.0.6
+      '@oxc-project/runtime': 0.51.0
+      '@oxc-project/types': 0.51.0
+      '@valibot/to-json-schema': 1.0.0-beta.5(valibot@1.0.0-beta.14)
+      valibot: 1.0.0-beta.14(typescript@5.4.5)
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.31.0
-      '@rollup/rollup-android-arm64': 4.31.0
-      '@rollup/rollup-darwin-arm64': 4.31.0
-      '@rollup/rollup-darwin-x64': 4.31.0
-      '@rollup/rollup-freebsd-arm64': 4.31.0
-      '@rollup/rollup-freebsd-x64': 4.31.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.31.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.31.0
-      '@rollup/rollup-linux-arm64-gnu': 4.31.0
-      '@rollup/rollup-linux-arm64-musl': 4.31.0
-      '@rollup/rollup-linux-loongarch64-gnu': 4.31.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.31.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.31.0
-      '@rollup/rollup-linux-s390x-gnu': 4.31.0
-      '@rollup/rollup-linux-x64-gnu': 4.31.0
-      '@rollup/rollup-linux-x64-musl': 4.31.0
-      '@rollup/rollup-win32-arm64-msvc': 4.31.0
-      '@rollup/rollup-win32-ia32-msvc': 4.31.0
-      '@rollup/rollup-win32-x64-msvc': 4.31.0
-      fsevents: 2.3.3
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.3-commit.b546e53
+    transitivePeerDependencies:
+      - typescript
     dev: false
 
   /run-parallel@1.2.0:
@@ -4813,13 +4978,14 @@ packages:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
     dev: false
 
-  /schema-utils@3.3.0:
-    resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
+  /schema-utils@4.3.0:
+    resolution: {integrity: sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==}
     engines: {node: '>= 10.13.0'}
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 6.12.6
-      ajv-keywords: 3.5.2(ajv@6.12.6)
+      ajv: 8.17.1
+      ajv-formats: 2.1.1(ajv@8.17.1)
+      ajv-keywords: 5.1.0(ajv@8.17.1)
     dev: false
 
   /semver@6.3.1:
@@ -5236,8 +5402,8 @@ packages:
       yallist: 4.0.0
     dev: false
 
-  /terser-webpack-plugin@5.3.10(webpack@5.92.1):
-    resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
+  /terser-webpack-plugin@5.3.11(webpack@5.98.0):
+    resolution: {integrity: sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -5254,19 +5420,19 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
-      schema-utils: 3.3.0
+      schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      terser: 5.31.1
-      webpack: 5.92.1
+      terser: 5.39.0
+      webpack: 5.98.0
     dev: false
 
-  /terser@5.31.1:
-    resolution: {integrity: sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==}
+  /terser@5.39.0:
+    resolution: {integrity: sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.11.3
+      acorn: 8.14.0
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: false
@@ -5374,8 +5540,8 @@ packages:
     resolution: {integrity: sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==}
     dev: false
 
-  /tsconfck@3.1.4(typescript@5.4.5):
-    resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
+  /tsconfck@3.1.5(typescript@5.4.5):
+    resolution: {integrity: sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
@@ -5518,14 +5684,14 @@ packages:
       picocolors: 1.0.0
     dev: true
 
-  /update-browserslist-db@1.1.0(browserslist@4.23.2):
-    resolution: {integrity: sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==}
+  /update-browserslist-db@1.1.2(browserslist@4.24.4):
+    resolution: {integrity: sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.23.2
-      escalade: 3.1.2
+      browserslist: 4.24.4
+      escalade: 3.2.0
       picocolors: 1.1.1
     dev: false
 
@@ -5564,6 +5730,17 @@ packages:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: false
 
+  /valibot@1.0.0-beta.14(typescript@5.4.5):
+    resolution: {integrity: sha512-tLyV2rE5QL6U29MFy3xt4AqMrn+/HErcp2ZThASnQvPMwfSozjV1uBGKIGiegtZIGjinJqn0SlBdannf18wENA==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.4.5
+    dev: false
+
   /vercel@34.0.0:
     resolution: {integrity: sha512-0Gewf/gB/UDnkGA/wyAzf3wxXuDqCvPFKFkAcByV3PuoCF5j71MqjV3GpFC0rQREF7CZZflFMhoaQO70a9x/fA==}
     engines: {node: '>= 16'}
@@ -5588,7 +5765,7 @@ packages:
       - supports-color
     dev: false
 
-  /vite-tsconfig-paths@5.1.4(typescript@5.4.5)(vite@6.0.11):
+  /vite-tsconfig-paths@5.1.4(typescript@5.4.5)(vite@6.1.0):
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
     peerDependencies:
       vite: '*'
@@ -5598,62 +5775,14 @@ packages:
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
-      tsconfck: 3.1.4(typescript@5.4.5)
-      vite: 6.0.11(@types/node@20.12.7)
+      tsconfck: 3.1.5(typescript@5.4.5)
+      vite: '@pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.12.7)(typescript@5.4.5)'
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /vite@6.0.11(@types/node@20.12.7):
-    resolution: {integrity: sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-    dependencies:
-      '@types/node': 20.12.7
-      esbuild: 0.24.2
-      postcss: 8.5.1
-      rollup: 4.31.0
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: false
-
-  /vitefu@1.0.5(vite@6.0.11):
+  /vitefu@1.0.5(vite@6.1.0):
     resolution: {integrity: sha512-h4Vflt9gxODPFNGPwp4zAMZRpZR7eslzwH2c5hn5kNZ5rhnKyRJ50U+yGCdc2IRaBs8O4haIgLNGrV5CrpMsCA==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
@@ -5661,11 +5790,11 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 6.0.11(@types/node@20.12.7)
+      vite: '@pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.12.7)(typescript@5.4.5)'
     dev: false
 
-  /watchpack@2.4.1:
-    resolution: {integrity: sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==}
+  /watchpack@2.4.2:
+    resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
     engines: {node: '>=10.13.0'}
     dependencies:
       glob-to-regexp: 0.4.1
@@ -5685,8 +5814,8 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: false
 
-  /webpack@5.92.1:
-    resolution: {integrity: sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==}
+  /webpack@5.98.0:
+    resolution: {integrity: sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -5697,14 +5826,13 @@ packages:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.11.3
-      acorn-import-attributes: 1.9.5(acorn@8.11.3)
-      browserslist: 4.23.2
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.14.0
+      browserslist: 4.24.4
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.0
+      enhanced-resolve: 5.18.1
       es-module-lexer: 1.6.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -5714,10 +5842,10 @@ packages:
       loader-runner: 4.3.0
       mime-types: 2.1.35
       neo-async: 2.6.2
-      schema-utils: 3.3.0
+      schema-utils: 4.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.92.1)
-      watchpack: 2.4.1
+      terser-webpack-plugin: 5.3.11(webpack@5.98.0)
+      watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -5897,7 +6025,7 @@ packages:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
     dev: false
 
-  '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server-next@e154a87(@hiogawa/react-server@0.4.1)(react-dom@19.0.0)(react@19.0.0)(typescript@5.4.5)(vite@6.0.11)':
+  '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server-next@e154a87(@hiogawa/react-server@0.4.1)(react-dom@19.0.0)(react@19.0.0)(typescript@5.4.5)(vite@6.1.0)':
     resolution: {tarball: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server-next@e154a87}
     id: '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server-next@e154a87'
     name: '@hiogawa/react-server-next'
@@ -5913,25 +6041,25 @@ packages:
       wrangler:
         optional: true
     dependencies:
-      '@hiogawa/react-server': '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server@e154a87(react-dom@19.0.0)(react-server-dom-webpack@19.0.0)(react@19.0.0)(vite@6.0.11)'
-      '@hiogawa/vite-plugin-server-asset': '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-server-asset@e154a878efd3a40e8691df6ffa55bc9389d07805(vite@6.0.11)'
-      '@hiogawa/vite-plugin-ssr-middleware': '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-ssr-middleware@e154a878efd3a40e8691df6ffa55bc9389d07805(vite@6.0.11)'
+      '@hiogawa/react-server': '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server@e154a87(react-dom@19.0.0)(react-server-dom-webpack@19.0.0)(react@19.0.0)(vite@6.1.0)'
+      '@hiogawa/vite-plugin-server-asset': '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-server-asset@e154a878efd3a40e8691df6ffa55bc9389d07805(vite@6.1.0)'
+      '@hiogawa/vite-plugin-ssr-middleware': '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-ssr-middleware@e154a878efd3a40e8691df6ffa55bc9389d07805(vite@6.1.0)'
       '@vercel/og': 0.6.5
-      '@vitejs/plugin-react-swc': 3.7.2(vite@6.0.11)
+      '@vitejs/plugin-react-swc': 3.8.0(vite@6.1.0)
       esbuild: 0.24.2
       fast-glob: 3.3.3
       magic-string: 0.30.17
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      vite: 6.0.11(@types/node@20.12.7)
-      vite-tsconfig-paths: 5.1.4(typescript@5.4.5)(vite@6.0.11)
+      vite: '@pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.12.7)(typescript@5.4.5)'
+      vite-tsconfig-paths: 5.1.4(typescript@5.4.5)(vite@6.1.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - supports-color
       - typescript
     dev: false
 
-  '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server@e154a87(react-dom@19.0.0)(react-server-dom-webpack@19.0.0)(react@19.0.0)(vite@6.0.11)':
+  '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server@e154a87(react-dom@19.0.0)(react-server-dom-webpack@19.0.0)(react@19.0.0)(vite@6.1.0)':
     resolution: {tarball: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server@e154a87}
     id: '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/react-server@e154a87'
     name: '@hiogawa/react-server'
@@ -5947,9 +6075,9 @@ packages:
       fast-glob: 3.3.3
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      react-server-dom-webpack: 19.0.0(react-dom@19.0.0)(react@19.0.0)(webpack@5.92.1)
-      vite: 6.0.11(@types/node@20.12.7)
-      vitefu: 1.0.5(vite@6.0.11)
+      react-server-dom-webpack: 19.0.0(react-dom@19.0.0)(react@19.0.0)(webpack@5.98.0)
+      vite: '@pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.12.7)(typescript@5.4.5)'
+      vitefu: 1.0.5(vite@6.1.0)
     dev: false
 
   '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/transforms@e154a878efd3a40e8691df6ffa55bc9389d07805':
@@ -5962,7 +6090,7 @@ packages:
       periscopic: 4.0.2
     dev: false
 
-  '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-server-asset@e154a878efd3a40e8691df6ffa55bc9389d07805(vite@6.0.11)':
+  '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-server-asset@e154a878efd3a40e8691df6ffa55bc9389d07805(vite@6.1.0)':
     resolution: {tarball: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-server-asset@e154a878efd3a40e8691df6ffa55bc9389d07805}
     id: '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-server-asset@e154a878efd3a40e8691df6ffa55bc9389d07805'
     name: '@hiogawa/vite-plugin-server-asset'
@@ -5971,10 +6099,10 @@ packages:
       vite: '*'
     dependencies:
       magic-string: 0.30.17
-      vite: 6.0.11(@types/node@20.12.7)
+      vite: '@pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.12.7)(typescript@5.4.5)'
     dev: false
 
-  '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-ssr-middleware@e154a878efd3a40e8691df6ffa55bc9389d07805(vite@6.0.11)':
+  '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-ssr-middleware@e154a878efd3a40e8691df6ffa55bc9389d07805(vite@6.1.0)':
     resolution: {tarball: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-ssr-middleware@e154a878efd3a40e8691df6ffa55bc9389d07805}
     id: '@pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-plugin-ssr-middleware@e154a878efd3a40e8691df6ffa55bc9389d07805'
     name: '@hiogawa/vite-plugin-ssr-middleware'
@@ -5982,5 +6110,59 @@ packages:
     peerDependencies:
       vite: '*'
     dependencies:
-      vite: 6.0.11(@types/node@20.12.7)
+      vite: '@pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.12.7)(typescript@5.4.5)'
+    dev: false
+
+  '@pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.12.7)(typescript@5.4.5)':
+    resolution: {tarball: https://pkg.pr.new/rolldown/vite@7e5a8b6}
+    id: '@pkg.pr.new/rolldown/vite@7e5a8b6'
+    name: vite
+    version: 6.1.0
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      esbuild: ^0.24.0
+      jiti: '>=1.21.0'
+      less: '*'
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      '@oxc-project/runtime': 0.51.0
+      '@types/node': 20.12.7
+      lightningcss: 1.29.1
+      postcss: 8.5.3
+      rolldown: 1.0.0-beta.3-commit.b546e53(@oxc-project/runtime@0.51.0)(typescript@5.4.5)
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - typescript
     dev: false


### PR DESCRIPTION
(prerendering is disabled for simplicity)

## todo

- [ ] make "jsx in js" opt-in since it currently relies on extra esbuild transform on all `.js` files?
  - for rolldown-vite, can we use `moduleType: { ".js": "jsx" }` instead?

### rolldown-vite

```sh
$ pnpm build

> @ build /home/hiroshi/code/others/app-playground
> next build

You have set `optimizeDeps.esbuildOptions` but this options is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rollupOptions` instead.
vite v6.1.0 building for production...
The built-in minifier is still under development. Setting "minify: true" is not recommended for production use.
▶▶▶ REACT SERVER BUILD (scan) [1/4]
You have set `optimizeDeps.esbuildOptions` but this options is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rollupOptions` instead.
You have set `optimizeDeps.esbuildOptions` but this options is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rollupOptions` instead. (x2)
You have set `optimizeDeps.esbuildOptions` but this options is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rollupOptions` instead. (x3)
You have set `optimizeDeps.esbuildOptions` but this options is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rollupOptions` instead. (x4)
vite v6.1.0 building SSR bundle for production...
transforming (1) virtual:entry-server-wrappertarget was modified to include ES2021 because useDefineForClassFields is set to false and oxc does not support transforming useDefineForClassFields=false for ES2022+ yet
transforming (21) app/page.tsxBrowserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
✓ 822 modules transformed.
dist/rsc/.vite/manifest.json                                  0.73 kB
dist/rsc/favicon.ico                                         15.09 kB
dist/rsc/assets/noto-sans-v27-latin-regular-CirskmZh.ttf     27.75 kB
dist/rsc/assets/yoga-CP4IUfLV.wasm                           88.66 kB
dist/rsc/assets/Inter-SemiBold-Cy6Rb6U-.ttf                 315.76 kB
dist/rsc/assets/resvg-Cjh1zH0p.wasm                       1,378.36 kB
dist/rsc/assets/index-C6_xhAjZ.css                           52.62 kB
dist/rsc/index.js                                             0.09 kB
✓ built in 1.17s
▶▶▶ REACT SERVER BUILD (server) [2/4]
vite v6.1.0 building SSR bundle for production...
✓ 808 modules transformed.
dist/rsc/.vite/manifest.json                                  2.32 kB
dist/rsc/favicon.ico                                         15.09 kB
dist/rsc/assets/noto-sans-v27-latin-regular-CirskmZh.ttf     27.75 kB
dist/rsc/assets/yoga-CP4IUfLV.wasm                           88.66 kB
dist/rsc/assets/Inter-SemiBold-Cy6Rb6U-.ttf                 315.76 kB
dist/rsc/assets/resvg-Cjh1zH0p.wasm                       1,378.36 kB
dist/rsc/assets/index-C6_xhAjZ.css                           52.62 kB
dist/rsc/assets/_virtual_server-references-dFAZrU9C.js        0.11 kB
dist/rsc/assets/client-CB1YArnh.js                            0.71 kB │ map:     0.94 kB
dist/rsc/index.js                                           230.01 kB │ map:   353.43 kB
dist/rsc/assets/server-BK1ntV3r.js                          262.58 kB │ map:   472.01 kB
dist/rsc/assets/index.edge-DACiyHhG.js                      670.90 kB │ map: 1,216.86 kB
✓ built in 1.19s
▶▶▶ REACT SERVER BUILD (browser) [3/4]
transforming (1) virtual:entry-client-wrappertarget was modified to include ES2021 because useDefineForClassFields is set to false and oxc does not support transforming useDefineForClassFields=false for ES2022+ yet
✓ 384 modules transformed.
dist/client/favicon.ico                                        15.09 kB
dist/client/.vite/manifest.json                                17.99 kB │ gzip:  2.01 kB
dist/client/assets/page-BFiv6r8l.css                            0.80 kB │ gzip:  0.31 kB
dist/client/assets/client-vnUYlCAF.js                           0.01 kB │ gzip:  0.03 kB
dist/client/assets/link-DzZakpKl.js                             0.01 kB │ gzip:  0.03 kB
dist/client/assets/counter-context-CBJWsFNY.js                  0.17 kB │ gzip:  0.13 kB
dist/client/assets/cart-count-context-Bwp6HrCS.js               0.18 kB │ gzip:  0.14 kB
dist/client/assets/link-0spWFzhU.js                             0.22 kB │ gzip:  0.17 kB
dist/client/assets/cart-count-BUo06_Io.js                       0.26 kB │ gzip:  0.19 kB
dist/client/assets/tab-BcX9wKWE.js                              0.29 kB │ gzip:  0.20 kB
dist/client/assets/client-CqqSway-.js                           0.38 kB │ gzip:  0.22 kB
dist/client/assets/clsx-Bb7oF98Z.js                             0.40 kB │ gzip:  0.25 kB
dist/client/assets/buggy-button-C2ldhK4W.js                     0.41 kB │ gzip:  0.29 kB
dist/client/assets/click-counter-B3QvxwW9.js                    0.42 kB │ gzip:  0.29 kB
dist/client/assets/button-DRN3dzRo.js                           0.43 kB │ gzip:  0.28 kB
dist/client/assets/image-Dvt9gLNM.js                            0.45 kB │ gzip:  0.29 kB
dist/client/assets/counter-context-eh5St9cL.js                  0.51 kB │ gzip:  0.28 kB
dist/client/assets/cart-count-context-Bs9aDndb.js               0.57 kB │ gzip:  0.31 kB
dist/client/assets/tab-DnufRRrb.js                              0.61 kB │ gzip:  0.40 kB
dist/client/assets/jsx-runtime-COgEExjB.js                      0.64 kB │ gzip:  0.37 kB
dist/client/assets/active-link-D5x9ScCW.js                      0.67 kB │ gzip:  0.42 kB
dist/client/assets/nav-links-dOkcP_8T.js                        0.72 kB │ gzip:  0.43 kB
dist/client/assets/navigation-Cns2W7vU.js                       0.76 kB │ gzip:  0.35 kB
dist/client/assets/registry-BeLEY3SB.js                         0.77 kB │ gzip:  0.41 kB
dist/client/assets/error-gnxaeBFO.js                            0.78 kB │ gzip:  0.40 kB
dist/client/assets/error-CqPw97A6.js                            0.79 kB │ gzip:  0.41 kB
dist/client/assets/chunk-W5G5lrKu.js                            0.80 kB │ gzip:  0.43 kB
dist/client/assets/error-AMUj-nRl.js                            0.81 kB │ gzip:  0.42 kB
dist/client/assets/random-post-tab-Bd5IqGKj.js                  0.82 kB │ gzip:  0.50 kB
dist/client/assets/router-context-layout-BRUsnP4W.js            0.83 kB │ gzip:  0.43 kB
dist/client/assets/router-context-6L6-7XC7.js                   1.00 kB │ gzip:  0.50 kB
dist/client/assets/context-click-counter-BGU39p8F.js            1.09 kB │ gzip:  0.48 kB
dist/client/assets/preload-helper-CdTX367H.js                   1.15 kB │ gzip:  0.68 kB
dist/client/assets/add-to-cart-B3klswpu.js                      1.16 kB │ gzip:  0.65 kB
dist/client/assets/page-DqjstfTS.js                             1.27 kB │ gzip:  0.40 kB
dist/client/assets/client-B46HyVGV.js                           1.36 kB │ gzip:  0.67 kB
dist/client/assets/boundary-yZroxDhH.js                         1.43 kB │ gzip:  0.61 kB
dist/client/assets/page-CHL8hkKe.js                             1.73 kB │ gzip:  0.59 kB
dist/client/assets/page-D2E0VWcL.js                             2.22 kB │ gzip:  0.64 kB
dist/client/assets/address-bar-Dcaf0xEF.js                      2.38 kB │ gzip:  0.81 kB
dist/client/assets/rendered-time-ago-BqWbTmSi.js                2.71 kB │ gzip:  1.26 kB
dist/client/assets/chunk-J2AD7JRE-DnRP6CiR.js                   3.68 kB │ gzip:  1.34 kB
dist/client/assets/react-dom-BH34x4ar.js                        3.87 kB │ gzip:  1.41 kB
dist/client/assets/_virtual_client-references-BD8IdUco.js       4.64 kB │ gzip:  1.36 kB
dist/client/assets/react-BX5LJtoz.js                            7.84 kB │ gzip:  2.89 kB
dist/client/assets/registry-BB2vaBhz.js                         9.30 kB │ gzip:  3.17 kB
dist/client/assets/global-nav-BYuSK7i3.js                      10.36 kB │ gzip:  3.59 kB
dist/client/assets/chunk-FACHSSON-HkW6kTJ0.js                  14.88 kB │ gzip:  5.29 kB
dist/client/assets/client.browser-DE9UM_Oi.js                  21.18 kB │ gzip:  6.98 kB
dist/client/assets/styled-components.browser.esm-KErCFzPy.js   30.02 kB │ gzip: 11.12 kB
dist/client/assets/virtualentry-client-wrapper-E7HHhBhb.js    182.36 kB │ gzip: 58.05 kB
▶▶▶ REACT SERVER BUILD (ssr) [4/4]
You have set `optimizeDeps.esbuildOptions` but this options is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rollupOptions` instead.
vite v6.1.0 building SSR bundle for production...
transforming (1) node_modules/.pnpm/@pkg.pr.new+hi-ogawa+vite-plugins+@hiogawa+react-server-next@e0b1164_@hiogawa+react-server@0._6hxq4ociwhkcisgorph6p6eiqu/node_modules/@hiogawa/react-server-next/dist/vite/entry-ssr.jstarget was modified to include ES2021 because useDefineForClassFields is set to false and oxc does not support transforming useDefineForClassFields=false for ES2022+ yet
✓ 52 modules transformed.
dist/server/.vite/manifest.json                            13.11 kB
dist/server/assets/client-D0oogLa3.js                       0.01 kB
dist/server/assets/link-V-9QxYT4.js                         0.01 kB
dist/server/assets/counter-context-qRQjgOA6.js              0.12 kB
dist/server/assets/cart-count-context-BCeNilWt.js           0.13 kB
dist/server/assets/link-BLPqAGlw.js                         0.14 kB
dist/server/assets/tab-BYNNgBZa.js                          0.19 kB
dist/server/assets/cart-count-BY7Hi4G9.js                   0.23 kB
dist/server/assets/buggy-button-C-W-Ra8C.js                 0.41 kB
dist/server/assets/click-counter-bWmbnqYL.js                0.42 kB
dist/server/assets/button-Cal8e56C.js                       0.42 kB
dist/server/assets/image-DbEkuO9T.js                        0.45 kB
dist/server/assets/_virtual_ssr-assets-DjsDKyfU.js          0.47 kB
dist/server/assets/counter-context-VU7gHQPL.js              0.52 kB
dist/server/assets/active-link-BSoRSor9.js                  0.64 kB
dist/server/assets/registry-rEQFnxSa.js                     0.68 kB
dist/server/assets/cart-count-context-cGMV595e.js           0.70 kB
dist/server/assets/tab-BawW8j8J.js                          0.73 kB
dist/server/assets/nav-links-CcFNpuMV.js                    0.73 kB
dist/server/assets/error-QsPW4ViG.js                        0.78 kB
dist/server/assets/error-BjZHamhy.js                        0.80 kB
dist/server/assets/error-CbQZ5m1K.js                        0.82 kB
dist/server/assets/registry-B3dj6AQR.js                     0.84 kB
dist/server/assets/router-context-layout-CCoKpt-b.js        0.86 kB
dist/server/assets/random-post-tab-c5Md6Js7.js              0.87 kB
dist/server/assets/navigation-_mSrdoET.js                   0.89 kB
dist/server/assets/chunk-DDPDL4YT-DYfmpdsN.js               1.03 kB
dist/server/assets/router-context-B_uUlVOw.js               1.12 kB
dist/server/assets/context-click-counter-Cf1WcbxQ.js        1.14 kB
dist/server/assets/page-DcZedSiS.js                         1.15 kB
dist/server/assets/rendered-time-ago-BvBV6ou3.js            1.20 kB
dist/server/assets/add-to-cart-CPzWeLRQ.js                  1.34 kB
dist/server/assets/page-BOLZON1x.js                         1.57 kB
dist/server/assets/boundary-BG_58gyX.js                     1.69 kB
dist/server/assets/_virtual_client-references--4djs5Uu.js   1.70 kB
dist/server/assets/client-xB8UyBIL.js                       1.74 kB
dist/server/assets/page-Widub4Qa.js                         2.06 kB
dist/server/assets/address-bar-ConvhHbl.js                  2.33 kB
dist/server/assets/client-DqsJXSIN.js                       3.98 kB
dist/server/assets/global-nav-DlBYhclC.js                   9.70 kB
dist/server/index.js                                       10.06 kB
dist/server/assets/chunk-FACHSSON-B3mjpni1.js              20.92 kB
dist/server/assets/_virtual_route-manifest-Cpb67y7I.js     31.92 kB
✓ built in 98ms
✓ built in 2.96s
```

## vite

```sh
$ pnpm build

> @ build /home/hiroshi/code/others/app-playground
> next build

vite v6.0.11 building for production...
▶▶▶ REACT SERVER BUILD (scan) [1/4]
vite v6.0.11 building SSR bundle for production...
transforming (141) app/ssg/template.tsxBrowserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
✓ 874 modules transformed.
dist/rsc/.vite/manifest.json                                  0.73 kB
dist/rsc/favicon.ico                                         15.09 kB
dist/rsc/assets/noto-sans-v27-latin-regular-CirskmZh.ttf     27.75 kB
dist/rsc/assets/yoga-CP4IUfLV.wasm                           88.66 kB
dist/rsc/assets/Inter-SemiBold-Cy6Rb6U-.ttf                 315.76 kB
dist/rsc/assets/resvg-Cjh1zH0p.wasm                       1,378.36 kB
dist/rsc/assets/index-Cyf_e1Dw.css                           52.22 kB
dist/rsc/index.js                                             0.13 kB │ map: 0.09 kB
✓ built in 935ms
▶▶▶ REACT SERVER BUILD (server) [2/4]
vite v6.0.11 building SSR bundle for production...
✓ 824 modules transformed.
dist/rsc/.vite/manifest.json                                  2.09 kB
dist/rsc/favicon.ico                                         15.09 kB
dist/rsc/assets/noto-sans-v27-latin-regular-CirskmZh.ttf     27.75 kB
dist/rsc/assets/yoga-CP4IUfLV.wasm                           88.66 kB
dist/rsc/assets/Inter-SemiBold-Cy6Rb6U-.ttf                 315.76 kB
dist/rsc/assets/resvg-Cjh1zH0p.wasm                       1,378.36 kB
dist/rsc/assets/index-Cyf_e1Dw.css                           52.22 kB
dist/rsc/assets/_virtual_server-references-y-E-dViC.js        0.15 kB │ map:     0.12 kB
dist/rsc/assets/client-zFMUo9On.js                            0.80 kB │ map:     1.02 kB
dist/rsc/index.js                                           561.64 kB │ map:   843.90 kB
dist/rsc/assets/index.edge-Ddb_Wnei.js                      707.64 kB │ map: 1,276.14 kB
✓ built in 1.35s
▶▶▶ REACT SERVER BUILD (browser) [3/4]
✓ 405 modules transformed.
dist/client/.vite/manifest.json                                11.40 kB │ gzip:  1.47 kB
dist/client/favicon.ico                                        15.09 kB
dist/client/assets/page-PdrCJy2t.css                            0.80 kB │ gzip:  0.31 kB
dist/client/assets/cart-count-DRtuWfJP.js                       0.21 kB │ gzip:  0.18 kB
dist/client/assets/buggy-button-CXJDKnV0.js                     0.33 kB │ gzip:  0.27 kB
dist/client/assets/image-CwEx_IeW.js                            0.34 kB │ gzip:  0.26 kB
dist/client/assets/click-counter-Cqnw7TaL.js                    0.35 kB │ gzip:  0.28 kB
dist/client/assets/clsx-B-dksMZM.js                             0.37 kB │ gzip:  0.24 kB
dist/client/assets/counter-context-CnOy2bQk.js                  0.38 kB │ gzip:  0.26 kB
dist/client/assets/button-D2Jjq4ed.js                           0.40 kB │ gzip:  0.28 kB
dist/client/assets/registry-Bdk8hxIk.js                         0.41 kB │ gzip:  0.29 kB
dist/client/assets/cart-count-context-DM1imCVu.js               0.43 kB │ gzip:  0.29 kB
dist/client/assets/navigation-C4kyQe4o.js                       0.43 kB │ gzip:  0.28 kB
dist/client/assets/active-link-DYv1Xz8T.js                      0.45 kB │ gzip:  0.32 kB
dist/client/assets/nav-links-B1IR5YHI.js                        0.50 kB │ gzip:  0.34 kB
dist/client/assets/tab-CkZoyjig.js                              0.50 kB │ gzip:  0.36 kB
dist/client/assets/router-context-layout-BLMTlSXk.js            0.52 kB │ gzip:  0.36 kB
dist/client/assets/random-post-tab-CkFBo1E2.js                  0.56 kB │ gzip:  0.41 kB
dist/client/assets/error-BJzR-N4I.js                            0.60 kB │ gzip:  0.39 kB
dist/client/assets/error-b6U8pGXD.js                            0.62 kB │ gzip:  0.40 kB
dist/client/assets/router-context-3v6CMg64.js                   0.63 kB │ gzip:  0.42 kB
dist/client/assets/error-CNAEXpBt.js                            0.63 kB │ gzip:  0.41 kB
dist/client/assets/page-CAyztwwk.js                             0.83 kB │ gzip:  0.37 kB
dist/client/assets/context-click-counter-BMOm97Bo.js            0.84 kB │ gzip:  0.44 kB
dist/client/assets/add-to-cart-Dhqeuo51.js                      0.90 kB │ gzip:  0.58 kB
dist/client/assets/client-CM3P0Oh9.js                           0.97 kB │ gzip:  0.56 kB
dist/client/assets/boundary-IbzX3yxJ.js                         1.29 kB │ gzip:  0.59 kB
dist/client/assets/page-BhfUbioG.js                             1.30 kB │ gzip:  0.53 kB
dist/client/assets/address-bar-tyPUyonJ.js                      1.68 kB │ gzip:  0.71 kB
dist/client/assets/page-Cpw8djtl.js                             1.87 kB │ gzip:  0.63 kB
dist/client/assets/rendered-time-ago-BWYYPa8A.js                2.40 kB │ gzip:  1.19 kB
dist/client/assets/_virtual_client-references-CBfOUAIV.js       3.68 kB │ gzip:  1.16 kB
dist/client/assets/registry-_53YD230.js                         8.67 kB │ gzip:  3.04 kB
dist/client/assets/global-nav-CfBJfEbO.js                       8.83 kB │ gzip:  3.38 kB
dist/client/assets/client.browser-DuDapd0r.js                  21.49 kB │ gzip:  7.32 kB
dist/client/assets/styled-components.browser.esm-BCpCXb9v.js   27.93 kB │ gzip: 10.88 kB
dist/client/assets/_virtual_entry-client-wrapper-B7TyoqBU.js  204.42 kB │ gzip: 65.71 kB
▶▶▶ REACT SERVER BUILD (ssr) [4/4]
vite v6.0.11 building SSR bundle for production...
✓ 52 modules transformed.
dist/server/.vite/manifest.json                            14.15 kB
dist/server/assets/link-DlS0SrIg.js                         0.18 kB
dist/server/assets/cart-count-DUssjh3z.js                   0.26 kB
dist/server/assets/_virtual_ssr-assets-CYmFJmRk.js          0.38 kB
dist/server/assets/button-CvBpoztf.js                       0.48 kB
dist/server/assets/click-counter-BoLI8bJT.js                0.49 kB
dist/server/assets/buggy-button-Bi8v7Ezc.js                 0.50 kB
dist/server/assets/image-BA6tifY5.js                        0.50 kB
dist/server/assets/counter-context-BcnCO_OI.js              0.55 kB
dist/server/assets/registry-BEYqq7AK.js                     0.71 kB
dist/server/assets/active-link-BVA68nt7.js                  0.73 kB
dist/server/assets/cart-count-context-ChfKBWqw.js           0.74 kB
dist/server/assets/error-1KlOEV56.js                        0.83 kB
dist/server/assets/nav-links-CbhHletT.js                    0.83 kB
dist/server/assets/error-Bl-1cWaE.js                        0.85 kB
dist/server/assets/registry-CZEyb_9K.js                     0.89 kB
dist/server/assets/error-CZyEc0YF.js                        0.92 kB
dist/server/assets/random-post-tab-CeBhzyVs.js              0.92 kB
dist/server/assets/navigation-vnK3Czlv.js                   0.95 kB
dist/server/assets/router-context-layout-frq3jmty.js        0.96 kB
dist/server/assets/tab-gki3_buh.js                          0.96 kB
dist/server/assets/router-context-B46ayOrn.js               1.23 kB
dist/server/assets/page-CApmTJi4.js                         1.23 kB
dist/server/assets/context-click-counter-ZgWGftDS.js        1.33 kB
dist/server/assets/rendered-time-ago-CM6QifT1.js            1.35 kB
dist/server/assets/add-to-cart-BwEywP6v.js                  1.57 kB
dist/server/assets/_virtual_client-references-DPOJ1lNm.js   1.71 kB
dist/server/assets/page-84kUsYiE.js                         1.77 kB
dist/server/assets/client-JnfBzWyU.js                       1.98 kB
dist/server/assets/boundary-CiTtoBmG.js                     2.18 kB
dist/server/assets/page-eQpP6KTD.js                         2.26 kB
dist/server/assets/address-bar-BQCRBCO0.js                  3.13 kB
dist/server/assets/client-BjzYzuhx.js                       3.77 kB
dist/server/assets/global-nav-khzgC3eq.js                  11.54 kB
dist/server/index.js                                       32.96 kB
dist/server/assets/_virtual_route-manifest-DOQz760M.js     36.60 kB
✓ built in 109ms
✓ built in 3.11s
``